### PR TITLE
Fixed XMLHttpRequest Capitalization Problem

### DIFF
--- a/docs/assignments/assignment5/index.html
+++ b/docs/assignments/assignment5/index.html
@@ -14,7 +14,7 @@
             <p class="lead">Due: Wednesday, November 28 at 11:59.999999 pm</p>
             <p class="lead">200 Points</p>
             <hr class="my-4">
-            <p>Work with XmlHttpRequest to create a &ldquo;real-time&rdquo; multiplayer Connect 4 game.</p>
+            <p>Work with XMLHttpRequest to create a &ldquo;real-time&rdquo; multiplayer Connect 4 game.</p>
         </div>
     </div>
     <div class="container">
@@ -30,7 +30,7 @@
             </div>
             <div class="col-md-9">
                 <h2 id="Connect-4-II%3A-The-AJAXening">Connect 4 II: The AJAXening</h2>
-                <p>Using the starter repository, modify the application so users can play against one another on different browsers without refreshing the page. The application should make use of the XmlHttpRequest object to send data back and forth between the client browsers and the server.</p>
+                <p>Using the starter repository, modify the application so users can play against one another on different browsers without refreshing the page. The application should make use of the XMLHttpRequest object to send data back and forth between the client browsers and the server.</p>
                 <h2 id="Specifications">Specifications</h2>
                 <p>These are the base requirements for making the page work. You can enhance.</p>
                 <h3 id="Dependencies">Dependencies</h3>
@@ -70,7 +70,7 @@
                             </li>
                         </ul>
                     </li>
-                    <li>The landing page should also include the ability for users to create new games (via <code>XmlHttpRequest</code>) that are added to their list without refreshing the entire page.</li>
+                    <li>The landing page should also include the ability for users to create new games (via <code>XMLHttpRequest</code>) that are added to their list without refreshing the entire page.</li>
                     <li>If a user is not logged in, they only see the top community scores without user names or links, and a prompt to login.</li>
                 </ul>
                 <h3 id="Games">Games</h3>
@@ -78,7 +78,7 @@
                     <li>Only the user who created the game can delete a game.</li>
                     <li>As users take turns the state of the game should be persisted to the database after each turn.
                         <ul>
-                            <li>The persistence should use XmlHttpRequest to persist the data to the server&ndash; no page refreshes allowed to persist data to the server during a game.</li>
+                            <li>The persistence should use XMLHttpRequest to persist the data to the server&ndash; no page refreshes allowed to persist data to the server during a game.</li>
                             <li>Data should persist to <code>localStorage</code> as well.</li>
                             <li>Only send new data (the difference) to a client&rsquo;s machine in response to a poll (not the entire state of of the board).</li>
                             <li>Only update the changed data on the screen in response to a poll, not rebuild the entire page.</li>


### PR DESCRIPTION
During class, there was an issue with creating a XmlHttpRequest object by doing `new XmlHttpRequest();`. The correct capitalization/convention is `XMLHttpRequest`, so the assignment page should reflect said convention.